### PR TITLE
legend key to gray for graph 1

### DIFF
--- a/surveygraphs.R
+++ b/surveygraphs.R
@@ -54,7 +54,8 @@ g1 <- ggplot(data=newdat,
        aes(long, lat))+
   geom_polygon(aes(group=group, fill=count),color="black")+
   theme_bw()+
-  theme(panel.background = element_rect(fill="darkgray"))+
+  theme(panel.background = element_rect(fill="darkgray"),
+        legend.key = element_rect(fill="darkgray"))+
   scale_fill_manual(breaks=uniquecounts,
                     values=uniquecolors)
 


### PR DESCRIPTION


the legend key needed a dark gray background so that the legend boxes matched the image

![survey_g1_world_map](https://user-images.githubusercontent.com/7707957/37597427-6ac383c8-2b4d-11e8-8a7c-1a1e826fbbbd.jpeg)
